### PR TITLE
feat: custom headers for disabling tracking of LHCI test runs

### DIFF
--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -20,3 +20,4 @@ jobs:
           urls: "${{ steps.sitemap-urls.outputs.urls }}"
           uploadArtifacts: true
           temporaryPublicStorage: true
+          configPath: 'lighthouserc.yaml'

--- a/lighthouserc.yaml
+++ b/lighthouserc.yaml
@@ -1,0 +1,4 @@
+ci:
+  collect:
+    settings:
+      extraHeaders: '{"Referer":"https://lhci.eearomatics.com"}'


### PR DESCRIPTION
Injects additional Referer header with sentinel value `https://lhci.eearomatics.com` to detect and bypass chat notifications and session tracking.